### PR TITLE
Add SASL bind support

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
                 "${workspaceFolder}/**",
                 "/usr/include/node"
             ],
-            "defines": ["LDAP_DEPRECATED"],
+            "defines": ["LDAP_DEPRECATED", "HAVE_CYRUS_SASL"],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
             "cppStandard": "c++17",

--- a/async_workers/bind.cpp
+++ b/async_workers/bind.cpp
@@ -3,37 +3,43 @@
 using namespace Napi;
 
 BindAsyncWorker::BindAsyncWorker(Napi::Env &env, LDAP *ld, std::string dn, std::string password, Napi::Promise::Deferred deferred)
-  : Napi::AsyncWorker(env), ld(ld), dn(dn), password(password), deferred(deferred) {}
+    : Napi::AsyncWorker(env), ld(ld), dn(dn), password(password), deferred(deferred) {}
 
 BindAsyncWorker::~BindAsyncWorker() {}
 
-void BindAsyncWorker::Execute() {
+void BindAsyncWorker::Execute()
+{
   LDAPMessage *res;
-  struct timeval zerotime = { -1, 0 };
+  struct timeval zerotime = {-1, 0};
 
   int msgid = ldap_simple_bind(this->ld, this->dn.c_str(), this->password.c_str());
 
-  if (msgid == -1) {
+  if (msgid == -1)
+  {
     SetError("Error during ldap_simple_bind");
     return;
   }
 
   int rc = ldap_result(this->ld, msgid, LDAP_MSG_ALL, &zerotime, &res);
 
-  switch (rc) {
-    case -1:
-      break; // TODO: handle error
-    default:
-      if (ldap_result2error(this->ld, res, 1) != LDAP_SUCCESS) {
-        // TODO: handle error
-      }
+  switch (rc)
+  {
+  case -1:
+    break; // TODO: handle error
+  default:
+    if (ldap_result2error(this->ld, res, 1) != LDAP_SUCCESS)
+    {
+      // TODO: handle error
+    }
   }
 }
 
-void BindAsyncWorker::OnOK() {
+void BindAsyncWorker::OnOK()
+{
   deferred.Resolve(Env().Undefined());
 }
 
-void BindAsyncWorker::OnError(Napi::Error const &error) {
+void BindAsyncWorker::OnError(Napi::Error const &error)
+{
   deferred.Reject(error.Value());
 }

--- a/async_workers/bind.h
+++ b/async_workers/bind.h
@@ -3,7 +3,8 @@
 #include <napi.h>
 #include <ldap.h>
 
-class BindAsyncWorker : public Napi::AsyncWorker {
+class BindAsyncWorker : public Napi::AsyncWorker
+{
 public:
   BindAsyncWorker(Napi::Env &env, LDAP *ld, std::string dn, std::string password, Napi::Promise::Deferred deferred);
   ~BindAsyncWorker();

--- a/async_workers/saslbind.cpp
+++ b/async_workers/saslbind.cpp
@@ -1,0 +1,120 @@
+#include <sasl/sasl.h>
+#include "saslbind.h"
+
+using namespace Napi;
+
+static int sasl_callback(LDAP *ld, unsigned flags, void *defaults, void *sasl_interact)
+{
+  struct sasl_defaults *user_provided_sasl_defaults = (struct sasl_defaults *)defaults;
+  sasl_interact_t *current_sasl_interact;
+
+  for (current_sasl_interact = (sasl_interact_t *)sasl_interact; current_sasl_interact->id != SASL_CB_LIST_END; current_sasl_interact++)
+  {
+    switch (current_sasl_interact->id)
+    {
+    case SASL_CB_AUTHNAME:
+      current_sasl_interact->result = user_provided_sasl_defaults->user;
+      break;
+    case SASL_CB_PASS:
+      current_sasl_interact->result = user_provided_sasl_defaults->password;
+      break;
+    case SASL_CB_USER:
+      current_sasl_interact->result = user_provided_sasl_defaults->proxy_user;
+      break;
+    case SASL_CB_GETREALM:
+      current_sasl_interact->result = user_provided_sasl_defaults->realm;
+      break;
+    default:
+      break;
+    }
+  }
+
+  return SASL_OK;
+}
+
+SaslBindAsyncWorker::SaslBindAsyncWorker(
+    Napi::Env &env,
+    LDAP *ld,
+    std::string mechanism,
+    std::string *user,
+    std::string *password,
+    std::string *realm,
+    std::string *proxy_user,
+    Napi::Promise::Deferred deferred) : Napi::AsyncWorker(env), ld(ld), mechanism(mechanism), user(user), password(password), realm(realm), proxy_user(proxy_user), deferred(deferred)
+{
+  this->defaults.user = user == NULL ? NULL : user->c_str();
+  this->defaults.password = password == NULL ? NULL : password->c_str();
+  this->defaults.realm = realm == NULL ? NULL : realm->c_str();
+  this->defaults.proxy_user = proxy_user == NULL ? NULL : proxy_user->c_str();
+}
+
+SaslBindAsyncWorker::~SaslBindAsyncWorker() {
+  if (this->user) delete this->user;
+  if (this->password) delete this->password;
+  if (this->realm) delete this->realm;
+  if (this->proxy_user) delete this->proxy_user;
+}
+
+void SaslBindAsyncWorker::Execute()
+{
+  LDAPControl **ctrls = NULL;
+  char **refs = NULL;
+  char *matched = NULL;
+  char *info = NULL;
+  LDAPControl **sctrlsp = NULL;
+  int rc, msgid, err;
+
+  LDAPMessage *result = NULL;
+  const char *rmech = NULL;
+
+  do
+  {
+    rc = ldap_sasl_interactive_bind(this->ld, NULL, this->mechanism.c_str(),
+                                    sctrlsp, NULL, LDAP_SASL_QUIET, sasl_callback, &this->defaults,
+                                    result, &rmech, &msgid);
+
+    if (rc != LDAP_SASL_BIND_IN_PROGRESS)
+    {
+      break;
+    }
+
+    ldap_msgfree(result);
+
+    if (ldap_result(this->ld, msgid, LDAP_MSG_ALL, NULL, &result) == -1 || !result)
+    {
+      ldap_get_option(this->ld, LDAP_OPT_RESULT_CODE, (void *)&err);
+      ldap_get_option(this->ld, LDAP_OPT_DIAGNOSTIC_MESSAGE, (void *)&info);
+      ldap_memfree(info);
+      SetError("Error during ldap_sasl_interactive_bind");
+      return;
+    }
+  } while (rc == LDAP_SASL_BIND_IN_PROGRESS);
+
+  if (rc != LDAP_SUCCESS)
+  {
+    ldap_get_option(this->ld, LDAP_OPT_DIAGNOSTIC_MESSAGE, (void *)&info);
+    ldap_memfree(info);
+    SetError("Error during ldap_sasl_interactive_bind");
+    return;
+  }
+
+  if (result)
+  {
+    rc = ldap_parse_result(this->ld, result, &err, &matched, &info, &refs, &ctrls, 1);
+    if (rc != LDAP_SUCCESS)
+    {
+      SetError("Error during ldap_sasl_interactive_bind");
+      return;
+    }
+  }
+}
+
+void SaslBindAsyncWorker::OnOK()
+{
+  deferred.Resolve(Env().Undefined());
+}
+
+void SaslBindAsyncWorker::OnError(Napi::Error const &error)
+{
+  deferred.Reject(error.Value());
+}

--- a/async_workers/saslbind.h
+++ b/async_workers/saslbind.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <napi.h>
+#include <ldap.h>
+
+typedef struct sasl_defaults
+{
+  const char *user = NULL;
+  const char *password = NULL;
+  const char *realm = NULL;
+  const char *proxy_user = NULL;
+} sasl_defaults;
+
+class SaslBindAsyncWorker : public Napi::AsyncWorker
+{
+public:
+  SaslBindAsyncWorker(Napi::Env &env, LDAP *ld, std::string mechanism, std::string *user, std::string *password, std::string *realm, std::string *proxy_user, Napi::Promise::Deferred deferred);
+  ~SaslBindAsyncWorker();
+  void Execute();
+  void OnOK();
+  void OnError(Napi::Error const &error);
+
+private:
+  LDAP *ld;
+  std::string mechanism;
+  std::string *user;
+  std::string *password;
+  std::string *realm;
+  std::string *proxy_user;
+  sasl_defaults defaults;
+  Napi::Promise::Deferred deferred;
+};

--- a/async_workers/search.cpp
+++ b/async_workers/search.cpp
@@ -3,57 +3,66 @@
 using namespace Napi;
 
 SearchAsyncWorker::SearchAsyncWorker(Napi::Env &env, LDAP *ld, int msgid, Napi::Promise::Deferred deferred)
-  : Napi::AsyncWorker(env), ld(ld), msgid(msgid), deferred(deferred) {}
+    : Napi::AsyncWorker(env), ld(ld), msgid(msgid), deferred(deferred) {}
 
 SearchAsyncWorker::~SearchAsyncWorker() {}
 
-void SearchAsyncWorker::Execute() {
+void SearchAsyncWorker::Execute()
+{
   LDAPMessage *res;
-  BerElement * ber;
+  BerElement *ber;
   LDAPMessage *entry;
   char *dn, *attrname;
   struct berval **vals;
   int num_vals;
 
   int i, j, rc;
-  struct timeval zerotime = { -1, 0 };
+  struct timeval zerotime = {-1, 0};
 
   rc = ldap_result(this->ld, this->msgid, LDAP_MSG_ALL, &zerotime, &res);
-  switch (rc) {
-    case LDAP_RES_SEARCH_ENTRY:
-    case LDAP_RES_SEARCH_RESULT:
-      for (entry = ldap_first_entry(this->ld, res), i = 0; entry; entry = ldap_next_entry(this->ld, entry), i++) {
-        dn = ldap_get_dn(this->ld, entry);
-        results.push_back({
-          {"dn", { std::string(dn) }},
-        });
+  switch (rc)
+  {
+  case LDAP_RES_SEARCH_ENTRY:
+  case LDAP_RES_SEARCH_RESULT:
+    for (entry = ldap_first_entry(this->ld, res), i = 0; entry; entry = ldap_next_entry(this->ld, entry), i++)
+    {
+      dn = ldap_get_dn(this->ld, entry);
+      results.push_back({
+          {"dn", {std::string(dn)}},
+      });
 
-        for (attrname = ldap_first_attribute(this->ld, entry, &ber); attrname; attrname = ldap_next_attribute(this->ld, entry, ber)) {
-          vals = ldap_get_values_len(this->ld, entry, attrname);
-          num_vals = ldap_count_values_len(vals);
+      for (attrname = ldap_first_attribute(this->ld, entry, &ber); attrname; attrname = ldap_next_attribute(this->ld, entry, ber))
+      {
+        vals = ldap_get_values_len(this->ld, entry, attrname);
+        num_vals = ldap_count_values_len(vals);
 
-          for (j = 0; j < num_vals; j++) {
-            results[i][std::string(attrname)].push_back(std::string(vals[j]->bv_val));
-          }
-
-          ldap_value_free_len(vals);
-          ldap_memfree(attrname);
+        for (j = 0; j < num_vals; j++)
+        {
+          results[i][std::string(attrname)].push_back(std::string(vals[j]->bv_val));
         }
+
+        ldap_value_free_len(vals);
+        ldap_memfree(attrname);
       }
-    default:
-      break;
+    }
+  default:
+    break;
   }
 
   ldap_msgfree(res);
 }
 
-void SearchAsyncWorker::OnOK() {
+void SearchAsyncWorker::OnOK()
+{
   Napi::Array res_array = Napi::Array::New(Env(), results.size());
-  for(uint i = 0; i < results.size(); i++) {
+  for (uint i = 0; i < results.size(); i++)
+  {
     Napi::Object obj = Napi::Object::New(Env());
-    for (auto const& attr : results[i]) {
+    for (auto const &attr : results[i])
+    {
       Napi::Array attr_array = Napi::Array::New(Env(), attr.second.size());
-      for (uint j = 0; j < attr.second.size(); j++) {
+      for (uint j = 0; j < attr.second.size(); j++)
+      {
         attr_array[j] = Napi::String::New(Env(), attr.second[j]);
       }
       obj.Set(attr.first, attr_array);
@@ -63,6 +72,7 @@ void SearchAsyncWorker::OnOK() {
   deferred.Resolve(res_array);
 }
 
-void SearchAsyncWorker::OnError(Napi::Error const &error) {
+void SearchAsyncWorker::OnError(Napi::Error const &error)
+{
   deferred.Reject(error.Value());
 }

--- a/async_workers/search.h
+++ b/async_workers/search.h
@@ -4,7 +4,8 @@
 #include <napi.h>
 #include <ldap.h>
 
-class SearchAsyncWorker : public Napi::AsyncWorker {
+class SearchAsyncWorker : public Napi::AsyncWorker
+{
 public:
   SearchAsyncWorker(Napi::Env &env, LDAP *ld, int msgid, Napi::Promise::Deferred deferred);
   ~SearchAsyncWorker();

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'SASL': '<!(test -f /usr/include/sasl/sasl.h && echo y || echo n)'
+  },
   'targets': [
     {
       'target_name': 'zephon_ldap',
@@ -6,7 +9,8 @@
         './main.cpp',
         './cnx.cpp',
         './async_workers/search.cpp',
-        './async_workers/bind.cpp'
+        './async_workers/bind.cpp',
+        './async_workers/saslbind.cpp'
       ],
       'dependencies': [
         '<!(node -p "require(\'node-addon-api\').gyp")'
@@ -29,6 +33,16 @@
       ],
       'libraries': [
         '-lldap'
+      ],
+      'conditions': [
+        [
+          'SASL==\"y\"',
+          {
+            'defines': [
+              'HAVE_CYRUS_SASL'
+            ]
+          }
+        ]
       ]
     }
   ]

--- a/cnx.cpp
+++ b/cnx.cpp
@@ -3,86 +3,84 @@
 #include "cnx.h"
 #include "async_workers/search.h"
 #include "async_workers/bind.h"
+#include "async_workers/saslbind.h"
 
 using namespace Napi;
 
-Napi::Object LDAPCnx::Init(Napi::Env env, Napi::Object exports) {
-    Napi::Function func = DefineClass(env, "LDAPCnx", {
-        InstanceMethod<&LDAPCnx::Search>("search", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::Delete>("delete", static_cast<napi_property_attributes>(napi_default_method)),
-        InstanceMethod<&LDAPCnx::Bind>("bind", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::Add>("add", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::Modify>("modify", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::Rename>("rename", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::Abandon>("abandon", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::ErrorString>("errorstring", static_cast<napi_property_attributes>(napi_default_method)),
-        InstanceMethod<&LDAPCnx::Close>("close", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::ErrNo>("errno", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::Fd>("fd", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::InstallTls>("installtls", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::StartTls>("starttls", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::CheckTls>("checktls", static_cast<napi_property_attributes>(napi_default_method)),
-        // InstanceMethod<&LDAPCnx::SaslBind>("saslbind", static_cast<napi_property_attributes>(napi_default_method)),
-    });
+Napi::Object LDAPCnx::Init(Napi::Env env, Napi::Object exports)
+{
+  Napi::Function func = DefineClass(env, "LDAPCnx", {
+                                                        InstanceMethod<&LDAPCnx::Search>("search", static_cast<napi_property_attributes>(napi_default_method)),
+                                                        InstanceMethod<&LDAPCnx::Bind>("bind", static_cast<napi_property_attributes>(napi_default_method)),
+                                                        InstanceMethod<&LDAPCnx::Close>("close", static_cast<napi_property_attributes>(napi_default_method)),
+                                                        InstanceMethod<&LDAPCnx::SaslBind>("saslbind", static_cast<napi_property_attributes>(napi_default_method)),
+                                                    });
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
+  Napi::FunctionReference *constructor = new Napi::FunctionReference();
 
-    // Create a persistent reference to the class constructor. This will allow
-    // a function called on a class prototype and a function
-    // called on instance of a class to be distinguished from each other.
-    *constructor = Napi::Persistent(func);
-    exports.Set("LDAPCnx", func);
-    env.SetInstanceData<Napi::FunctionReference>(constructor);
+  // Create a persistent reference to the class constructor. This will allow
+  // a function called on a class prototype and a function
+  // called on instance of a class to be distinguished from each other.
+  *constructor = Napi::Persistent(func);
+  exports.Set("LDAPCnx", func);
+  env.SetInstanceData<Napi::FunctionReference>(constructor);
 
-    return exports;
+  return exports;
 }
 
-LDAPCnx::LDAPCnx(const Napi::CallbackInfo& info) : Napi::ObjectWrap<LDAPCnx>(info) {
+LDAPCnx::LDAPCnx(const Napi::CallbackInfo &info) : Napi::ObjectWrap<LDAPCnx>(info)
+{
   int ver = LDAP_VERSION3;
-  
+
   Napi::Env env = info.Env();
   std::string arg_url = info[0].As<Napi::String>();
 
-  if (ldap_initialize(&(this->ld), arg_url.c_str()) != LDAP_SUCCESS) {
+  if (ldap_initialize(&(this->ld), arg_url.c_str()) != LDAP_SUCCESS)
+  {
     throw Napi::Error::New(env, "Error intializing ldap");
   }
 
   ldap_set_option(this->ld, LDAP_OPT_PROTOCOL_VERSION, &ver);
 }
 
-Napi::Value LDAPCnx::Search(const Napi::CallbackInfo& info) {
+Napi::Value LDAPCnx::Search(const Napi::CallbackInfo &info)
+{
   int msgid = 0;
   LDAPControl *page_control[2];
-  
+
   Napi::Env env = info.Env();
+  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
   std::string arg_base = info[0].As<Napi::String>();
   std::string arg_filter = info[1].As<Napi::String>();
   Napi::Array arg_attrs = info[2].As<Napi::Array>();
 
   std::vector<std::string> attributes;
 
-  for(uint i = 0; i < arg_attrs.Length(); i++) {
-    std::string attr = ((Napi::Value) arg_attrs[i]).As<Napi::String>();
+  for (uint i = 0; i < arg_attrs.Length(); i++)
+  {
+    std::string attr = ((Napi::Value)arg_attrs[i]).As<Napi::String>();
     attributes.push_back(attr);
   }
 
-  std::vector<const char*> attrs;
+  std::vector<const char *> attrs;
   std::transform(std::begin(attributes), std::end(attributes), std::back_inserter(attrs), std::mem_fn(&std::string::c_str));
   attrs.push_back(NULL);
 
   memset(&page_control, 0, sizeof(page_control));
 
-  if (ldap_search_ext(this->ld, arg_base.c_str(), 2, arg_filter.c_str(), (char**)attrs.data(), 0, page_control, NULL, NULL, 0, &msgid) != LDAP_SUCCESS) {
-    throw Napi::Error::New(env, "Error searching ldap");
+  if (ldap_search_ext(this->ld, arg_base.c_str(), 2, arg_filter.c_str(), (char **)attrs.data(), 0, page_control, NULL, NULL, 0, &msgid) != LDAP_SUCCESS)
+  {
+    deferred.Reject(Napi::Error::New(env, "Error searching ldap").Value());
+    return deferred.Promise();
   }
 
-  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
   SearchAsyncWorker *searchAsyncWorker = new SearchAsyncWorker(env, this->ld, msgid, deferred);
   searchAsyncWorker->Queue();
   return deferred.Promise();
 }
 
-Napi::Value LDAPCnx::Bind(const Napi::CallbackInfo& info) {
+Napi::Value LDAPCnx::Bind(const Napi::CallbackInfo &info)
+{
   Napi::Env env = info.Env();
 
   std::string arg_dn = info[0].As<Napi::String>();
@@ -94,10 +92,41 @@ Napi::Value LDAPCnx::Bind(const Napi::CallbackInfo& info) {
   return deferred.Promise();
 }
 
-Napi::Value LDAPCnx::Close(const Napi::CallbackInfo& info) {
+Napi::Value LDAPCnx::Close(const Napi::CallbackInfo &info)
+{
   Napi::Env env = info.Env();
 
   ldap_unbind(this->ld);
 
   return env.Undefined();
+}
+
+Napi::Value LDAPCnx::SaslBind(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
+#ifdef HAVE_CYRUS_SASL
+  std::string arg_mechanism = info[0].As<Napi::String>();
+  std::string *arg_user = NULL, *arg_password = NULL, *arg_realm = NULL, *arg_proxy_user = NULL;
+
+  if (info.Length() == 2)
+  {
+    Napi::Object options = info[1].As<Napi::Object>();
+    Napi::Value user_value = options.Get("user");
+    if (!user_value.IsUndefined()) arg_user = new std::string(user_value.As<Napi::String>());
+    Napi::Value password_value = options.Get("password");
+    if (!password_value.IsUndefined()) arg_password = new std::string(password_value.As<Napi::String>());
+    Napi::Value realm_value = options.Get("realm");
+    if (!realm_value.IsUndefined()) arg_realm = new std::string(realm_value.As<Napi::String>());
+    Napi::Value proxy_user_value = options.Get("proxy_user");
+    if (!proxy_user_value.IsUndefined()) arg_proxy_user = new std::string(proxy_user_value.As<Napi::String>());
+  }
+
+  SaslBindAsyncWorker *saslBindAsyncWorker = new SaslBindAsyncWorker(env, this->ld, arg_mechanism, arg_user, arg_password, arg_realm, arg_proxy_user, deferred);
+  saslBindAsyncWorker->Queue();
+  
+#else
+  deferred.Reject(Napi::Error::New(env, "Not compiled with SASL support").Value());
+#endif
+  return deferred.Promise();
 }

--- a/cnx.h
+++ b/cnx.h
@@ -16,14 +16,16 @@ struct ldap_cnx
   napi_env env;
 };
 
-class LDAPCnx : public Napi::ObjectWrap<LDAPCnx> {
-  public:
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    LDAPCnx(const Napi::CallbackInfo& info);
+class LDAPCnx : public Napi::ObjectWrap<LDAPCnx>
+{
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
+  LDAPCnx(const Napi::CallbackInfo &info);
 
-  private:
-    LDAP *ld;
-    Napi::Value Search(const Napi::CallbackInfo& info);
-    Napi::Value Bind(const Napi::CallbackInfo& info);
-    Napi::Value Close(const Napi::CallbackInfo& info);
+private:
+  LDAP *ld;
+  Napi::Value Search(const Napi::CallbackInfo &info);
+  Napi::Value Bind(const Napi::CallbackInfo &info);
+  Napi::Value Close(const Napi::CallbackInfo &info);
+  Napi::Value SaslBind(const Napi::CallbackInfo &info);
 };

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,8 @@
 
 using namespace Napi;
 
-Napi::Object Init(Napi::Env env, Napi::Object exports) {
+Napi::Object Init(Napi::Env env, Napi::Object exports)
+{
     LDAPCnx::Init(env, exports);
     return exports;
 }


### PR DESCRIPTION
Work in progress SASL bind support.

TODO:
- ~Test~ Manged to test with GSSAPI and it worked. The case when there's no SASL support is probably not handled correctly though. I might need to do the same thing as `napi-ldap` did where I include a "dummy" cpp file which don't require the `sasl/sasl.h` header to be present on the system.
- ~Read more LDAP docs~
- ~Carefully review sequence of ldap_sasl_interactive_bind ldap_result calls and possible error scenarios~ I'm still pretty sure that not everything is handled 100% correctly regarding the sequence and memory allocations and all the different possible auth mechanisms. But it seems to work for my use case.
- ~Add way for end user to provide SASL defaults (user, realm, etc...)~